### PR TITLE
HAS-124: fix Dockerfile layered extraction for Spring Boot 4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@ FROM amd64/eclipse-temurin:21.0.6_7-jdk-alpine AS builder
 WORKDIR /application
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
-RUN java -Djarmode=layertools -jar application.jar extract
+RUN java -Djarmode=tools -jar application.jar extract --layers --destination extracted
 
 FROM amd64/eclipse-temurin:21.0.6_7-jdk-alpine
 WORKDIR /application
-COPY --from=builder application/dependencies/ ./
-COPY --from=builder application/spring-boot-loader/ ./
-COPY --from=builder application/snapshot-dependencies/ ./
-COPY --from=builder application/application/ ./
+COPY --from=builder /application/extracted/dependencies/ ./
+COPY --from=builder /application/extracted/spring-boot-loader/ ./
+COPY --from=builder /application/extracted/snapshot-dependencies/ ./
+COPY --from=builder /application/extracted/application/ ./
 
 RUN apk add --no-cache tzdata
 ENV TZ="Europe/Warsaw"
@@ -17,5 +17,5 @@ ENV TZ="Europe/Warsaw"
 VOLUME /tmp
 USER nobody:nobody
 
-ENTRYPOINT ["java", "-XshowSettings:vm", "-XX:+UseZGC", "-XX:MaxRAMPercentage=75.0", "org.springframework.boot.loader.launch.JarLauncher"]
+ENTRYPOINT ["java", "-XshowSettings:vm", "-XX:+UseZGC", "-XX:MaxRAMPercentage=75.0", "-jar", "application.jar"]
 EXPOSE 6200 9200


### PR DESCRIPTION
## Why
The `0.1.0` release failed at the **Build and push Docker image** step:

```
process "/bin/sh -c java -Djarmode=layertools -jar application.jar extract" did not complete successfully: exit code: 1
```

Spring Boot 4 removed the `layertools` jarmode (`Error: Unsupported jarmode 'layertools'`). The Java 21 migration bumped the Dockerfile base image but not the layered-extraction command, so `release.yml` builds the jar fine but the image build fails — no image reaches Docker Hub.

## What
- `-Djarmode=tools ... extract --layers --destination extracted`
- copy layers from the new `extracted/` destination
- entrypoint `-jar application.jar` — the `tools` layout ships a runnable jar in the application layer and leaves `spring-boot-loader` empty, so the old `JarLauncher` main-class entrypoint no longer applies

## Verified locally (Docker daemon unavailable in WSL)
- old command reproduces the failure: `Unsupported jarmode 'layertools'`
- new command extracts the four layer dirs
- flattened layout (as the final image stage assembles it) boots: `java -jar application.jar` → Netty started on 6003, context up

🤖 Generated with [Claude Code](https://claude.com/claude-code)